### PR TITLE
Fix Binance websocket import path

### DIFF
--- a/src/controllers/data_controller.py
+++ b/src/controllers/data_controller.py
@@ -11,7 +11,7 @@ import threading
 from typing import List, Optional
 
 from binance.client import Client
-from binance.streams import ThreadedWebsocketManager
+from binance import ThreadedWebsocketManager
 
 from models.app_state import AppState, MarketFrame
 from config import config


### PR DESCRIPTION
## Summary
- fix import for `ThreadedWebsocketManager` from updated `python-binance` library

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893c31772d483229f7e2686c955cd6c