### PR TITLE
Add unit tests for market state, Binance client, and database

### DIFF
--- a/tests/test_binance_client.py
+++ b/tests/test_binance_client.py
@@ -1,1 +1,55 @@
+import pytest
+from crypto_analyzer.models.binance_client import BinanceClient
 
+
+@pytest.fixture
+def client_with_mocks(mocker):
+    client_cls = mocker.patch('crypto_analyzer.models.binance_client.Client')
+    twm_cls = mocker.patch('crypto_analyzer.models.binance_client.ThreadedWebsocketManager')
+    client_instance = client_cls.return_value
+    twm_instance = twm_cls.return_value
+    bc = BinanceClient('key', 'secret', testnet=True)
+    return bc, client_instance, twm_instance
+
+
+def test_get_klines(client_with_mocks):
+    bc, client_instance, _ = client_with_mocks
+    client_instance.get_klines.return_value = ['data']
+
+    result = bc.get_klines('BTCUSDT', '1m', limit=10)
+
+    client_instance.get_klines.assert_called_once_with(symbol='BTCUSDT', interval='1m', limit=10)
+    assert result == ['data']
+
+
+def test_start_kline_socket(client_with_mocks):
+    bc, _, twm_instance = client_with_mocks
+    callback = lambda x: x
+
+    bc.start_kline_socket('BTCUSDT', '1m', callback)
+
+    twm_instance.start.assert_called_once()
+    twm_instance.start_kline_socket.assert_called_once_with(symbol='BTCUSDT', interval='1m', callback=callback)
+    assert bc._twm is twm_instance
+
+
+def test_start_depth_socket(client_with_mocks):
+    bc, _, twm_instance = client_with_mocks
+    callback = lambda x: x
+
+    bc.start_depth_socket('BTCUSDT', callback)
+
+    twm_instance.start.assert_called_once()
+    twm_instance.start_depth_socket.assert_called_once_with(symbol='BTCUSDT', callback=callback)
+    assert bc._twm is twm_instance
+
+
+def test_stop(client_with_mocks):
+    bc, _, twm_instance = client_with_mocks
+    callback = lambda x: x
+
+    bc.start_kline_socket('BTCUSDT', '1m', callback)
+    bc.stop()
+
+    twm_instance.stop.assert_called_once()
+    assert bc._twm is None

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,1 +1,35 @@
+import sqlite3
+import pytest
+from crypto_analyzer.models.database import Database
 
+
+@pytest.fixture
+def db(tmp_path):
+    database = Database(str(tmp_path / 'test.db'))
+    yield database
+    database.close()
+
+
+def test_connection(db):
+    conn1 = db.connect()
+    assert isinstance(conn1, sqlite3.Connection)
+    conn2 = db.connect()
+    assert conn1 is conn2
+    db.close()
+    assert db._conn is None
+
+
+def test_crud_operations(db):
+    db.create_table('CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)')
+
+    db.insert('test', {'id': 1, 'name': 'alpha'})
+    rows = db.select('test')
+    assert rows == [(1, 'alpha')]
+
+    db.update('test', {'name': 'beta'}, 'id=?', (1,))
+    rows = db.select('test', 'id=?', (1,))
+    assert rows == [(1, 'beta')]
+
+    db.delete('test', 'id=?', (1,))
+    rows = db.select('test')
+    assert rows == []

--- a/tests/test_market_frame.py
+++ b/tests/test_market_frame.py
@@ -1,1 +1,72 @@
+import importlib
+import pytest
 
+
+@pytest.fixture
+def app_state(monkeypatch):
+    from PyQt6 import QtCore
+
+    class DummySignal:
+        def __init__(self, *args, **kwargs):
+            self._slots = []
+
+        def connect(self, func):
+            self._slots.append(func)
+
+        def emit(self, *args, **kwargs):
+            for slot in self._slots:
+                slot(*args, **kwargs)
+
+    monkeypatch.setattr(QtCore, 'QObject', object)
+    monkeypatch.setattr(QtCore, 'pyqtSignal', lambda *a, **k: DummySignal())
+    import crypto_analyzer.models.app_state as module
+    importlib.reload(module)
+    AppState = module.AppState
+    MarketFrame = module.MarketFrame
+    AppState._instance = None
+    state = AppState()
+    yield state, MarketFrame
+    AppState._instance = None
+    importlib.reload(module)  # restore original for other tests
+
+
+def make_frame(MarketFrame, ts: int, *, open_price=1.0, high_price=2.0, low_price=0.5, close_price=1.5, volume=100.0, symbol="BTCUSDT", interval="1m"):
+    return MarketFrame(ts, symbol, open_price, high_price, low_price, close_price, volume, interval)
+
+
+def test_update_market_data_sets_latest_and_emits_signal(app_state):
+    state, MarketFrame = app_state
+    received = []
+    state.dataUpdated.connect(lambda frame: received.append(frame))
+
+    frame = make_frame(MarketFrame, 1)
+    state.update_market_data(frame)
+
+    assert state.latest_market_frame is frame
+    assert received == [frame]
+
+
+def test_candle_history_updates_and_limits(app_state):
+    state, MarketFrame = app_state
+    state.max_history_size = 2
+
+    frame1 = make_frame(MarketFrame, 1, close_price=10)
+    frame2 = make_frame(MarketFrame, 1, close_price=20)
+    frame3 = make_frame(MarketFrame, 2, close_price=30)
+    frame4 = make_frame(MarketFrame, 3, close_price=40)
+
+    state.update_market_data(frame1)
+    assert len(state.candle_history) == 1
+    assert state.candle_history[-1]["close"] == 10
+
+    state.update_market_data(frame2)
+    assert len(state.candle_history) == 1
+    assert state.candle_history[-1]["close"] == 20
+
+    state.update_market_data(frame3)
+    assert len(state.candle_history) == 2
+    assert [c["timestamp"] for c in state.candle_history] == [1, 2]
+
+    state.update_market_data(frame4)
+    assert len(state.candle_history) == 2
+    assert [c["timestamp"] for c in state.candle_history] == [2, 3]


### PR DESCRIPTION
## Summary
- test AppState update logic and candle history handling
- add BinanceClient unit tests with mocked network layers
- verify basic SQLite operations in Database wrapper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893e395bafc8322998315acf6d56a96