### PR TITLE
Improve data directory handling and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ export BINANCE_API_SECRET="<your_api_secret>"
 Start the application with:
 
 ```bash
-python -m src.main
+python -m crypto_analyzer.main
+```
+
+## Testing
+
+Run the test suite with:
+
+```bash
+pytest
 ```
 
 ## Optional Features

--- a/crypto_analyzer/main.py
+++ b/crypto_analyzer/main.py
@@ -6,10 +6,7 @@ import sys
 import logging
 from pathlib import Path
 
-from PyQt6.QtWidgets import QApplication
 
-from .views.main_window import MainWindow
-from .models.app_state import AppState
 
 def setup_logging():
     """Konfiguracja logowania"""
@@ -22,9 +19,15 @@ def setup_logging():
         ]
     )
 
-def create_data_directory():
-    """Tworzy katalog dla bazy danych jeśli nie istnieje"""
-    data_dir = Path("data")
+def create_data_directory(path: str | Path = "data"):
+    """Tworzy katalog dla bazy danych jeśli nie istnieje.
+
+    Parameters
+    ----------
+    path: str | Path, optional
+        Ścieżka do katalogu danych. Domyślnie ``"data"``.
+    """
+    data_dir = Path(path)
     data_dir.mkdir(exist_ok=True)
 
 def main():
@@ -33,15 +36,20 @@ def main():
     # Konfiguracja środowiska
     setup_logging()
     create_data_directory()
-    
+
+    # Importy lokalne wymagające PyQt6
+    from PyQt6.QtWidgets import QApplication
+    from .models.app_state import AppState
+    from .views.main_window import MainWindow
+
     # Utworzenie aplikacji Qt
     app = QApplication(sys.argv)
     app.setApplicationName("Crypto Market Analyzer")
     app.setApplicationVersion("1.0.0")
-    
+
     # Inicjalizacja stanu aplikacji
     app_state = AppState()
-    
+
     # Utworzenie głównego okna
     main_window = MainWindow()
     main_window.show()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,8 @@
+from crypto_analyzer.main import create_data_directory
+
+
+def test_create_data_directory(tmp_path):
+    custom_dir = tmp_path / "data"
+    create_data_directory(custom_dir)
+    assert custom_dir.exists()
+    assert custom_dir.is_dir()


### PR DESCRIPTION
## Summary
- allow specifying custom data directory in `create_data_directory`
- document correct application start command and testing instructions
- test data directory creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e530bbc8832297df5da5833d7323