### PR TITLE
Add BTC chart with toggleable indicators

### DIFF
--- a/crypto_analyzer/models/app_state.py
+++ b/crypto_analyzer/models/app_state.py
@@ -33,6 +33,7 @@ class AppState(QObject):
     connectionStatusChanged = pyqtSignal(bool)  # True = connected, False = disconnected
     errorOccurred = pyqtSignal(str)  # Komunikat błędu
     themeChanged = pyqtSignal(str)  # 'light' lub 'dark'
+    indicatorConfigChanged = pyqtSignal()  # Zmiana konfiguracji wskaźników
     
     _instance: Optional['AppState'] = None
     _lock = threading.Lock()
@@ -137,6 +138,7 @@ class AppState(QObject):
         if indicator_name in self.active_indicators:
             self.active_indicators[indicator_name]['enabled'] = enabled
             self.active_indicators[indicator_name].update(params)
+            self.indicatorConfigChanged.emit()
     
     def get_enabled_indicators(self) -> Dict[str, Dict[str, Any]]:
         """Zwraca listę włączonych wskaźników"""

--- a/crypto_analyzer/views/chart_view.py
+++ b/crypto_analyzer/views/chart_view.py
@@ -1,12 +1,103 @@
-"""Simple placeholder widget for chart display."""
-from PyQt6.QtWidgets import QWidget, QLabel, QVBoxLayout
+"""Candlestick chart widget with optional technical indicators."""
+
+from __future__ import annotations
+
+import pandas as pd
+import mplfinance as mpf
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from PyQt6.QtWidgets import QWidget, QVBoxLayout
+
+from ..models.app_state import AppState
+from ..config import config
 
 
 class ChartView(QWidget):
-    """Placeholder chart widget."""
+    """Displays market data as a candlestick chart."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+
+        self.app_state = AppState()
+
+        self.figure = Figure(figsize=(5, 4))
+        self.canvas = FigureCanvas(self.figure)
+
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Chart view placeholder"))
+        layout.addWidget(self.canvas)
+
+        # React to state changes
+        self.app_state.dataUpdated.connect(self._on_data)
+        self.app_state.themeChanged.connect(lambda _t: self.plot())
+        self.app_state.indicatorConfigChanged.connect(self.plot)
+
+    # ------------------------------------------------------------------
+    # Signal handlers
+    # ------------------------------------------------------------------
+    def _on_data(self, _frame) -> None:
+        """Replot chart when new market data arrives."""
+        self.plot()
+
+    # ------------------------------------------------------------------
+    # Plotting helpers
+    # ------------------------------------------------------------------
+    def _get_style(self):
+        theme = self.app_state.current_theme
+        colors = config.chart.colors_dark if theme == "dark" else config.chart.colors_light
+        mc = mpf.make_marketcolors(up=colors["up"], down=colors["down"])
+        return mpf.make_mpf_style(
+            marketcolors=mc,
+            facecolor=colors["background"],
+            edgecolor=colors["grid"],
+            gridcolor=colors["grid"],
+            rc={
+                "axes.labelcolor": colors["text"],
+                "axes.edgecolor": colors["text"],
+                "xtick.color": colors["text"],
+                "ytick.color": colors["text"],
+            },
+        )
+
+    def plot(self) -> None:
+        """Render candlestick chart with active indicators."""
+        data = self.app_state.candle_history
+        if not data:
+            return
+
+        df = pd.DataFrame(data)
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+        df.set_index("timestamp", inplace=True)
+
+        apds = []
+        indicators = self.app_state.get_enabled_indicators()
+        if "sma_fast" in indicators:
+            period = indicators["sma_fast"].get("period", 9)
+            df["sma_fast"] = df["close"].rolling(period).mean()
+            apds.append(mpf.make_addplot(df["sma_fast"]))
+        if "sma_slow" in indicators:
+            period = indicators["sma_slow"].get("period", 21)
+            df["sma_slow"] = df["close"].rolling(period).mean()
+            apds.append(mpf.make_addplot(df["sma_slow"]))
+        if "bollinger_bands" in indicators:
+            period = indicators["bollinger_bands"].get("period", 20)
+            std_dev = indicators["bollinger_bands"].get("std_dev", 2)
+            ma = df["close"].rolling(period).mean()
+            std = df["close"].rolling(period).std()
+            df["bb_upper"] = ma + std_dev * std
+            df["bb_lower"] = ma - std_dev * std
+            apds.append(mpf.make_addplot(df["bb_upper"], color="grey"))
+            apds.append(mpf.make_addplot(df["bb_lower"], color="grey"))
+
+        self.figure.clear()
+        ax = self.figure.add_subplot(111)
+        mpf.plot(
+            df,
+            type="candle",
+            ax=ax,
+            style=self._get_style(),
+            addplot=apds,
+            xrotation=15,
+            warn_too_much_data=10000,
+        )
+        self.canvas.draw()
 

--- a/crypto_analyzer/views/indicator_panel.py
+++ b/crypto_analyzer/views/indicator_panel.py
@@ -1,12 +1,31 @@
-"""Simple placeholder widget for indicator controls."""
-from PyQt6.QtWidgets import QWidget, QLabel, QVBoxLayout
+"""Panel providing basic indicator toggles."""
+
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QCheckBox, QLabel
+
+from ..models.app_state import AppState
 
 
 class IndicatorPanel(QWidget):
-    """Placeholder indicator panel widget."""
+    """Allows enabling or disabling sample indicators."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self.app_state = AppState()
+
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Indicator panel placeholder"))
+        layout.addWidget(QLabel("Wskaźniki"))
+
+        self.sma_fast = QCheckBox("SMA Fast (9)")
+        self.sma_fast.toggled.connect(lambda s: self.app_state.update_indicator("sma_fast", s))
+        layout.addWidget(self.sma_fast)
+
+        self.sma_slow = QCheckBox("SMA Slow (21)")
+        self.sma_slow.toggled.connect(lambda s: self.app_state.update_indicator("sma_slow", s))
+        layout.addWidget(self.sma_slow)
+
+        self.bb = QCheckBox("Bollinger Bands")
+        self.bb.toggled.connect(lambda s: self.app_state.update_indicator("bollinger_bands", s))
+        layout.addWidget(self.bb)
+
+        layout.addStretch()
 

--- a/tests/test_app_state_indicators.py
+++ b/tests/test_app_state_indicators.py
@@ -1,0 +1,50 @@
+import importlib
+import pytest
+
+
+@pytest.fixture
+def app_state(monkeypatch):
+    from PyQt6 import QtCore
+
+    class DummySignal:
+        def __init__(self, *args, **kwargs):
+            self._slots = []
+
+        def connect(self, func):
+            self._slots.append(func)
+
+        def emit(self, *args, **kwargs):
+            for slot in self._slots:
+                slot(*args, **kwargs)
+
+    monkeypatch.setattr(QtCore, "QObject", object)
+    monkeypatch.setattr(QtCore, "pyqtSignal", lambda *a, **k: DummySignal())
+    import crypto_analyzer.models.app_state as module
+    importlib.reload(module)
+    AppState = module.AppState
+    AppState._instance = None
+    state = AppState()
+    yield state
+    AppState._instance = None
+    importlib.reload(module)
+
+
+def test_update_indicator_emits_signal(app_state):
+    received = []
+    app_state.indicatorConfigChanged.connect(lambda: received.append(True))
+
+    app_state.update_indicator("sma_fast", True, period=5)
+
+    assert app_state.active_indicators["sma_fast"]["enabled"] is True
+    assert received == [True]
+
+
+def test_get_enabled_indicators(app_state):
+    app_state.update_indicator("sma_fast", True, period=5)
+    app_state.update_indicator("sma_slow", False)
+
+    enabled = app_state.get_enabled_indicators()
+
+    assert "sma_fast" in enabled
+    assert "sma_slow" not in enabled
+


### PR DESCRIPTION
## Summary
- Render real-time candlestick chart for selected symbol with optional SMA and Bollinger overlays
- Provide indicator panel to toggle common indicators
- Signal indicator configuration changes via AppState

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e834c66c83228e1452b7d25afe61