### PR TITLE
Enable script execution by using absolute imports in main

### DIFF
--- a/crypto_analyzer/main.py
+++ b/crypto_analyzer/main.py
@@ -39,8 +39,10 @@ def main():
 
     # Importy lokalne wymagające PyQt6
     from PyQt6.QtWidgets import QApplication
-    from .models.app_state import AppState
-    from .views.main_window import MainWindow
+    # Używamy bezwzględnych importów, aby skrypt można było uruchomić
+    # również bez kontekstu pakietu (np. `python crypto_analyzer/main.py`).
+    from crypto_analyzer.models.app_state import AppState
+    from crypto_analyzer.views.main_window import MainWindow
 
     # Utworzenie aplikacji Qt
     app = QApplication(sys.argv)


### PR DESCRIPTION
## Summary
- use absolute imports in `main.py` so the app can be run as `python crypto_analyzer/main.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689534b393fc8322ae2607a1a74136e3